### PR TITLE
feat: indent group attributes, add tests

### DIFF
--- a/devslog.go
+++ b/devslog.go
@@ -1,6 +1,7 @@
 package devslog
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -11,11 +12,10 @@ import (
 
 // A Handler handles log records produced by a Logger.
 type Handler struct {
-	attrs  []slog.Attr
-	groups []string
-	opts   slog.HandlerOptions
-	mu     *sync.Mutex
-	w      io.Writer
+	opts slog.HandlerOptions
+	mu   *sync.Mutex
+	w    io.Writer
+	goas []groupOrAttrs
 }
 
 // NewHandler creates a handler that writes to w, using the given options.
@@ -44,50 +44,140 @@ func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
 // WithAttrs returns a new handler whose attributes consists of h's attributes
 // followed by attrs.
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &Handler{
-		attrs:  append(h.attrs, attrs...),
-		groups: h.groups,
-		opts:   h.opts,
-		mu:     h.mu,
-		w:      h.w,
+	if len(attrs) < 1 {
+		return h
 	}
+
+	return h.withGroupOrAttrs(groupOrAttrs{attrs: attrs})
 }
 
 // WithGroup returns a new Handler with the given group appended to
 // the receiver's existing groups.
 func (h *Handler) WithGroup(name string) slog.Handler {
-	return &Handler{
-		attrs:  h.attrs,
-		groups: append(h.groups, name),
-		opts:   h.opts,
-		mu:     h.mu,
-		w:      h.w,
+	if name == "" {
+		return h
 	}
+
+	return h.withGroupOrAttrs(groupOrAttrs{group: name})
 }
 
 // Handle formats its argument Record so that message is followed by each
 // of it's attributes on seperate lines.
 func (h *Handler) Handle(_ context.Context, r slog.Record) error {
-	var attrs string
+	var buf bytes.Buffer
 
-	for _, a := range h.attrs {
-		if !a.Equal(slog.Attr{}) {
-			attrs += gray(" ↳ " + a.Key + ": " + a.Value.String() + "\n")
+	// From slog handler docs:
+	// 	If r.Time is the zero time, ignore the time.
+	if !r.Time.IsZero() {
+		_, _ = buf.WriteString(r.Time.Format(time.TimeOnly) + " ")
+	}
+	_, _ = buf.WriteString(text(levelColour(r.Level), r.Level.String()) + " " + r.Message + "\n")
+
+	// In this handler, each attribute that is not one of the built-in attributes
+	// is written on its own line. For group attributes, use indentation level to
+	// display different levels.
+	var indentLevel int
+	goas := h.goas
+	if r.NumAttrs() == 0 {
+		// If the record has no Attrs, remove groups at the end of the list; they are empty.
+		for len(goas) > 0 && goas[len(goas)-1].group != "" {
+			goas = goas[:len(goas)-1]
 		}
 	}
-
-	r.Attrs(func(a slog.Attr) bool {
-		if !a.Equal(slog.Attr{}) {
-			attrs += gray(" ↳ " + a.Key + ": " + a.Value.String() + "\n")
+	for _, goa := range goas {
+		if goa.group != "" {
+			_, _ = fmt.Fprintf(&buf, "%*s %s %s:\n", indentLevel*numSpacesPerLevel, "", attrPrefix, gray(goa.group))
+			indentLevel++
+		} else {
+			for _, a := range goa.attrs {
+				h.appendAttr(&buf, a, indentLevel)
+			}
 		}
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		h.appendAttr(&buf, a, indentLevel)
 		return true
 	})
 
 	h.mu.Lock()
-	_, err := fmt.Fprintf(h.w, "%s %s %s\n%s", r.Time.Format(time.TimeOnly), text(levelColour(r.Level), r.Level.String()), r.Message, attrs)
+	_, err := h.w.Write(buf.Bytes())
 	h.mu.Unlock()
 
 	return err
+}
+
+const (
+	// attrPrefix denotes that another attribute value will be printed in the
+	// output. For this handler, it will be preceded by a newline character.
+	attrPrefix = "↳"
+	// kvd is the key value delimiter output between an attribute's key and value.
+	kvd = ":"
+	// numSpacesPerLevel is an indentation value for spacing group attributes.
+	numSpacesPerLevel = 4
+)
+
+func (h *Handler) appendAttr(buf *bytes.Buffer, a slog.Attr, indentLevel int) {
+	// From slog handler docs:
+	// 	Attr's values should be resolved.
+	a.Value = a.Value.Resolve()
+
+	// From slog handler docs:
+	// 	If an Attr's key and value are both the zero value, ignore the Attr.
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+
+	_, _ = fmt.Fprintf(buf, "%*s", indentLevel*numSpacesPerLevel, "")
+	switch a.Value.Kind() {
+	case slog.KindString:
+		_, _ = fmt.Fprintf(buf, " %s %s%s %s\n", attrPrefix, gray(a.Key), kvd, a.Value.String())
+	case slog.KindTime:
+		// Write times in the same layout as the built-in time attribute.
+		_, _ = fmt.Fprintf(buf, " %s %s%s %s\n", attrPrefix, gray(a.Key), kvd, a.Value.Time().Format(time.TimeOnly))
+	case slog.KindGroup:
+		attrs := a.Value.Group()
+
+		// From slog handler docs:
+		// 	If a group has no Attrs (even if it has a non-empty key), ignore it.
+		if len(attrs) == 0 {
+			return
+		}
+
+		// If the key is non-empty, write it out and indent the rest of the attrs.
+		// Otherwise, inline the attrs.
+		if a.Key != "" {
+			_, _ = fmt.Fprintf(buf, " %s %s:\n", attrPrefix, gray(a.Key))
+			indentLevel++
+		}
+
+		for _, ga := range attrs {
+			h.appendAttr(buf, ga, indentLevel)
+		}
+	default:
+		_, _ = fmt.Fprintf(buf, " %s %s%s %s\n", attrPrefix, gray(a.Key), kvd, a.Value)
+	}
+}
+
+// withGroupOrAttrs is for use in the Handler's WithAttrs or WithGroup methods.
+// The slog.Handler docs say that those methods must return a new Handler. So
+// this method clones the handler state but makes a deep copy of the goas field
+// with a new value at the end. The goal is to avoid potentially shared state
+// with another handler instance, should either of them append to the same
+// underlying array variable. So avoid that situation by making a deep copy.
+func (h *Handler) withGroupOrAttrs(goa groupOrAttrs) *Handler {
+	out := *h
+	out.goas = make([]groupOrAttrs, len(h.goas)+1)
+	copy(out.goas, h.goas)
+	out.goas[len(out.goas)-1] = goa
+	return &out
+}
+
+// groupOrAttrs holds either a group name or a list of slog.Attrs.
+// It is lifted from the slog-handler-guide at:
+// https://github.com/golang/example/blob/master/slog-handler-guide
+type groupOrAttrs struct {
+	group string      // group name if non-empty
+	attrs []slog.Attr // attrs if non-empty
 }
 
 // SetDefault is syntactic sugar for constructing a new devslog handler

--- a/devslog_test.go
+++ b/devslog_test.go
@@ -1,0 +1,212 @@
+package devslog
+
+import (
+	"bytes"
+	"log/slog"
+	"maps"
+	"strings"
+	"testing"
+	"testing/slogtest"
+	"time"
+)
+
+func TestSlogtest(t *testing.T) {
+	var buf bytes.Buffer
+	newHandler := func(t *testing.T) slog.Handler {
+		t.Helper()
+		buf.Reset()
+		return NewHandler(&buf, nil)
+	}
+	makeTestResults := func(t *testing.T) map[string]any {
+		t.Helper()
+
+		got := buf.String()
+		t.Log(got)
+		return parseMap(t, strings.Split(got, "\n"))
+	}
+
+	slogtest.Run(t, newHandler, makeTestResults)
+}
+
+// parseMap formats the output lines into a map for the slogtest tests.
+func parseMap(t *testing.T, lines []string) map[string]any {
+	t.Helper()
+
+	if len(lines) < 2 {
+		return nil
+	}
+
+	out := make(map[string]any)
+
+	// The first output line with the built-in attributes has a different format
+	// than the newline-delimited attributes afterwards. There are 2 or 3
+	// attributes on this line, depending on whether or not the time is present.
+	switch firstLineParts := strings.Split(lines[0], " "); len(firstLineParts) {
+	case 2:
+		out[slog.LevelKey] = stripANSI(firstLineParts[0])
+		out[slog.MessageKey] = firstLineParts[1]
+	case 3:
+		out[slog.TimeKey] = firstLineParts[0]
+		out[slog.LevelKey] = stripANSI(firstLineParts[1])
+		out[slog.MessageKey] = firstLineParts[2]
+	default:
+		t.Fatalf("unexpected number of parts for first line (%d), expected 2 or 3", len(firstLineParts))
+	}
+
+	// Any attributes added via WithAttr, WithGroup, or with the record via the
+	// Handle method are formatted 1 attribute per line.
+	attrsMap := mapAttrLines(t, lines[1:])
+	maps.Copy(out, attrsMap)
+
+	return out
+}
+
+// ansiColors are the same const values in color.go.
+var ansiColors = []string{
+	resetColour,
+	colourRed,
+	colourYellow,
+	colourWhite,
+	colorGray,
+}
+
+// stripANSI removes ANSI escape codes from line so that we can focus on the
+// data more clearly in these tests.
+func stripANSI(line string) string {
+	for _, color := range ansiColors {
+		line = strings.ReplaceAll(line, color, "")
+	}
+	return line
+}
+
+// mapAttrLines reads attribute lines from the handler output into a map for use
+// in slogtest tests. It's not meant to interpet the first line of the output;
+// that is reserved for the built-in attribute which have a different format
+// than the subsequent lines. This function handles the part of the output that
+// has 1 attribute per line: attributes that are *not* the built-in ones.
+func mapAttrLines(t *testing.T, lines []string) map[string]any {
+	t.Helper()
+
+	out := make(map[string]any)
+
+	// A mapContext combines a reference to the map being built and the expected
+	// indentation level of its direct children.
+	type mapContext struct {
+		m map[string]any
+		// indent is the number of leading spaces/indentation units for the
+		// map's direct children.
+		indent int
+	}
+
+	// stack aids in tracking the indentation level and to help us build
+	// attributes into the correct map.
+	stack := []mapContext{{m: out, indent: 0}}
+
+	for _, rawLine := range lines {
+		lineSansANSI := stripANSI(rawLine)
+
+		// Trim leading/trailing whitespace and the const `attrPrefix` from the
+		// content but preserve leading spaces for measuring indentation.
+		trimmedLine := strings.TrimSpace(lineSansANSI)
+		trimmedLine = strings.TrimPrefix(trimmedLine, attrPrefix)
+		trimmedLine = strings.TrimSpace(trimmedLine)
+
+		if trimmedLine == "" {
+			continue // Skip empty or whitespace-only lines
+		}
+
+		// Parse the indentation level, key and value in two stages. Use const
+		// values known to be in the output lines.
+		// 1. Separate the key from the value. The segment that is separate
+		//    from the value would also include indentation, if any. Use the
+		//    const, keyValDelimiter.
+		// 2. Then separate the indentation from the key. Use const, attrPrefix.
+		indentPlusKey, rawValue, found := strings.Cut(lineSansANSI, kvd)
+		if !found {
+			t.Fatalf("invalid line, did not find keyValDelimiter %q, line: %q", kvd, lineSansANSI)
+		}
+
+		indent, rawKey, found := strings.Cut(indentPlusKey, attrPrefix)
+		if !found {
+			t.Fatalf(
+				"invalid line, did not find attrPrefix %q in the space before the keyValDelimiter, line_prefix: %q",
+				attrPrefix, indentPlusKey,
+			)
+		}
+
+		currentIndentation := len(indent)
+		key := strings.TrimSpace(rawKey)
+		value := strings.TrimSpace(rawValue)
+
+		if key == "" {
+			t.Fatalf("key cannot be empty, line: %q", lineSansANSI)
+		}
+
+		// Pop contexts from the stack until the current line's indentation is
+		// >= the current context's indent. Do this to surface the correct map
+		// to place the line's key and value.
+		for currentIndentation < stack[len(stack)-1].indent {
+			if len(stack) <= 1 {
+				// Should not happen for valid input because the top-level map
+				// has an indent value of 0.
+				break
+			}
+			stack = stack[:len(stack)-1] // Move up to the parent context
+		}
+
+		currentContext := stack[len(stack)-1]
+
+		if value != "" {
+			// This is a scalar value.
+			currentContext.m[key] = value
+		} else {
+			// An empty value here indicates a group attribute. It's a parent of
+			// some child lines, which will have more indentation than the
+			// current line. In the slogtest output map we're building, it's
+			// represented as another map.
+			newMap := make(map[string]any)
+
+			// Add the new map to the current map in the stack.
+			currentContext.m[key] = newMap
+
+			// Push a new map context onto the stack. Its children should have
+			// the same indentation + numSpacesPerLevel.
+			stack = append(stack, mapContext{
+				m:      newMap,
+				indent: currentIndentation + numSpacesPerLevel,
+			})
+		}
+	}
+
+	return out
+}
+
+func TestHandler(t *testing.T) {
+	t.Run("times are written in consistent layout", func(t *testing.T) {
+		now := time.Date(2009, time.November, 9, 23, 0, 0, 0, time.UTC)
+		rec := slog.NewRecord(now, slog.LevelInfo, "msg", 0)
+		rec.AddAttrs(slog.Time("foo", now))
+		var buf bytes.Buffer
+
+		err := NewHandler(&buf, nil).Handle(t.Context(), rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lines := buf.String()
+		t.Logf("%s", lines)
+		parsedMap := parseMap(t, strings.Split(lines, "\n"))
+
+		gotTime, ok := parsedMap[slog.TimeKey]
+		if !ok {
+			t.Fatalf("expected to find key %s", slog.TimeKey)
+		}
+		gotFoo, ok := parsedMap["foo"]
+		if !ok {
+			t.Fatalf("expected to find key %s", "foo")
+		}
+		if gotFoo != gotTime {
+			t.Errorf("expected for time values to be the same; got %v, expected %v", gotFoo, gotTime)
+		}
+	})
+}


### PR DESCRIPTION
Reference issue: romantomjak/devslog#1

* When a group attribute is printed, the group name is put on its own line. Its "child" attributes are each indented and puts onto their own line. If one of the children is itself a group, then the process repeats, but starting at the current indentation level. The implementation adapts from code, concepts mentioned in https://github.com/golang/example/blob/master/slog-handler-guide.
* Add tests. Test against the tests in the testing/slogtest package. These are the same tests to check the standard library's slog.TextHandler, slog.JSONHandler are behaving as expected. To get the tests to pass here, made some behavioral tweaks to the Handler methods. See the docs for log/slog.Handler for more info.
* Also updates coloring logic so that only the attribute key or group's name has a color. IMO, this makes it easier to see what part of the message is structural, and what's more specific to the event. In tests we need to parse the log entry, so its coloring is removed.
* Add unit test for consistent time layout.